### PR TITLE
added writePos macro

### DIFF
--- a/illwill.nim
+++ b/illwill.nim
@@ -1239,6 +1239,12 @@ template writeProcessArg(tb: var TerminalBuffer, cmd: TerminalCmd) =
   when cmd == resetStyle:
     tb.resetAttributes()
 
+macro writePos*(tb: var TerminalBuffer, x,y: int, args: varargs[typed]): untyped = 
+  result = newNimNode(nnkStmtList)
+  result.add(newCall(bindSym"setCursorPos", tb, x, y))
+  for i in 0..<args.len:
+    let item = args[i]
+    result.add(newCall(bindSym"writeProcessArg", tb, item))
 
 macro write*(tb: var TerminalBuffer, args: varargs[typed]): untyped =
   ## Special version of `write` that allows to intersperse text literals with

--- a/illwill.nim
+++ b/illwill.nim
@@ -1239,13 +1239,6 @@ template writeProcessArg(tb: var TerminalBuffer, cmd: TerminalCmd) =
   when cmd == resetStyle:
     tb.resetAttributes()
 
-macro writePos*(tb: var TerminalBuffer, x,y: int, args: varargs[typed]): untyped = 
-  result = newNimNode(nnkStmtList)
-  result.add(newCall(bindSym"setCursorPos", tb, x, y))
-  for i in 0..<args.len:
-    let item = args[i]
-    result.add(newCall(bindSym"writeProcessArg", tb, item))
-
 macro write*(tb: var TerminalBuffer, args: varargs[typed]): untyped =
   ## Special version of `write` that allows to intersperse text literals with
   ## set attribute commands.
@@ -1288,8 +1281,9 @@ macro write*(tb: var TerminalBuffer, args: varargs[typed]): untyped =
   ##
   ##
   result = newNimNode(nnkStmtList)
+
   if args.len >= 3 and
-     args[0].kind == nnkIntLit and args[1].kind == nnkIntLit:
+     args[0].typeKind() == ntyInt and args[1].typeKind() == ntyInt:
 
     let x = args[0]
     let y = args[1]


### PR DESCRIPTION
Signed-off-by: David Krause <david@code0.xyz>

issue was that `write` only accepted int literals but no variables.
