### PR TITLE
[WIP] Adding Javascript support

### DIFF
--- a/definitions.nim
+++ b/definitions.nim
@@ -1,0 +1,208 @@
+type
+  ForegroundColor* = enum   ## Foreground colors
+    fgNone = 0,             ## default
+    fgBlack = 30,           ## black
+    fgRed,                  ## red
+    fgGreen,                ## green
+    fgYellow,               ## yellow
+    fgBlue,                 ## blue
+    fgMagenta,              ## magenta
+    fgCyan,                 ## cyan
+    fgWhite                 ## white
+
+  BackgroundColor* = enum   ## Background colors
+    bgNone = 0,             ## default (transparent)
+    bgBlack = 40,           ## black
+    bgRed,                  ## red
+    bgGreen,                ## green
+    bgYellow,               ## yellow
+    bgBlue,                 ## blue
+    bgMagenta,              ## magenta
+    bgCyan,                 ## cyan
+    bgWhite                 ## white
+
+  Key* {.pure.} = enum      ## Supported single key presses and key combinations
+    None = (-1, "None"),
+
+    # Special ASCII characters
+    CtrlA  = (1, "CtrlA"),
+    CtrlB  = (2, "CtrlB"),
+    CtrlC  = (3, "CtrlC"),
+    CtrlD  = (4, "CtrlD"),
+    CtrlE  = (5, "CtrlE"),
+    CtrlF  = (6, "CtrlF"),
+    CtrlG  = (7, "CtrlG"),
+    CtrlH  = (8, "CtrlH"),
+    Tab    = (9, "Tab"),     # Ctrl-I
+    CtrlJ  = (10, "CtrlJ"),
+    CtrlK  = (11, "CtrlK"),
+    CtrlL  = (12, "CtrlL"),
+    Enter  = (13, "Enter"),  # Ctrl-M
+    CtrlN  = (14, "CtrlN"),
+    CtrlO  = (15, "CtrlO"),
+    CtrlP  = (16, "CtrlP"),
+    CtrlQ  = (17, "CtrlQ"),
+    CtrlR  = (18, "CtrlR"),
+    CtrlS  = (19, "CtrlS"),
+    CtrlT  = (20, "CtrlT"),
+    CtrlU  = (21, "CtrlU"),
+    CtrlV  = (22, "CtrlV"),
+    CtrlW  = (23, "CtrlW"),
+    CtrlX  = (24, "CtrlX"),
+    CtrlY  = (25, "CtrlY"),
+    CtrlZ  = (26, "CtrlZ"),
+    Escape = (27, "Escape"),
+
+    CtrlBackslash    = (28, "CtrlBackslash"),
+    CtrlRightBracket = (29, "CtrlRightBracket"),
+
+    # Printable ASCII characters
+    Space           = (32, "Space"),
+    ExclamationMark = (33, "ExclamationMark"),
+    DoubleQuote     = (34, "DoubleQuote"),
+    Hash            = (35, "Hash"),
+    Dollar          = (36, "Dollar"),
+    Percent         = (37, "Percent"),
+    Ampersand       = (38, "Ampersand"),
+    SingleQuote     = (39, "SingleQuote"),
+    LeftParen       = (40, "LeftParen"),
+    RightParen      = (41, "RightParen"),
+    Asterisk        = (42, "Asterisk"),
+    Plus            = (43, "Plus"),
+    Comma           = (44, "Comma"),
+    Minus           = (45, "Minus"),
+    Dot             = (46, "Dot"),
+    Slash           = (47, "Slash"),
+
+    Zero  = (48, "Zero"),
+    One   = (49, "One"),
+    Two   = (50, "Two"),
+    Three = (51, "Three"),
+    Four  = (52, "Four"),
+    Five  = (53, "Five"),
+    Six   = (54, "Six"),
+    Seven = (55, "Seven"),
+    Eight = (56, "Eight"),
+    Nine  = (57, "Nine"),
+
+    Colon        = (58, "Colon"),
+    Semicolon    = (59, "Semicolon"),
+    LessThan     = (60, "LessThan"),
+    Equals       = (61, "Equals"),
+    GreaterThan  = (62, "GreaterThan"),
+    QuestionMark = (63, "QuestionMark"),
+    At           = (64, "At"),
+
+    ShiftA  = (65, "ShiftA"),
+    ShiftB  = (66, "ShiftB"),
+    ShiftC  = (67, "ShiftC"),
+    ShiftD  = (68, "ShiftD"),
+    ShiftE  = (69, "ShiftE"),
+    ShiftF  = (70, "ShiftF"),
+    ShiftG  = (71, "ShiftG"),
+    ShiftH  = (72, "ShiftH"),
+    ShiftI  = (73, "ShiftI"),
+    ShiftJ  = (74, "ShiftJ"),
+    ShiftK  = (75, "ShiftK"),
+    ShiftL  = (76, "ShiftL"),
+    ShiftM  = (77, "ShiftM"),
+    ShiftN  = (78, "ShiftN"),
+    ShiftO  = (79, "ShiftO"),
+    ShiftP  = (80, "ShiftP"),
+    ShiftQ  = (81, "ShiftQ"),
+    ShiftR  = (82, "ShiftR"),
+    ShiftS  = (83, "ShiftS"),
+    ShiftT  = (84, "ShiftT"),
+    ShiftU  = (85, "ShiftU"),
+    ShiftV  = (86, "ShiftV"),
+    ShiftW  = (87, "ShiftW"),
+    ShiftX  = (88, "ShiftX"),
+    ShiftY  = (89, "ShiftY"),
+    ShiftZ  = (90, "ShiftZ"),
+
+    LeftBracket  = (91, "LeftBracket"),
+    Backslash    = (92, "Backslash"),
+    RightBracket = (93, "RightBracket"),
+    Caret        = (94, "Caret"),
+    Underscore   = (95, "Underscore"),
+    GraveAccent  = (96, "GraveAccent"),
+
+    A = (97, "A"),
+    B = (98, "B"),
+    C = (99, "C"),
+    D = (100, "D"),
+    E = (101, "E"),
+    F = (102, "F"),
+    G = (103, "G"),
+    H = (104, "H"),
+    I = (105, "I"),
+    J = (106, "J"),
+    K = (107, "K"),
+    L = (108, "L"),
+    M = (109, "M"),
+    N = (110, "N"),
+    O = (111, "O"),
+    P = (112, "P"),
+    Q = (113, "Q"),
+    R = (114, "R"),
+    S = (115, "S"),
+    T = (116, "T"),
+    U = (117, "U"),
+    V = (118, "V"),
+    W = (119, "W"),
+    X = (120, "X"),
+    Y = (121, "Y"),
+    Z = (122, "Z"),
+
+    LeftBrace  = (123, "LeftBrace"),
+    Pipe       = (124, "Pipe"),
+    RightBrace = (125, "RightBrace"),
+    Tilde      = (126, "Tilde"),
+    Backspace  = (127, "Backspace"),
+
+    # Special characters with virtual keycodes
+    Up       = (1001, "Up"),
+    Down     = (1002, "Down"),
+    Right    = (1003, "Right"),
+    Left     = (1004, "Left"),
+    Home     = (1005, "Home"),
+    Insert   = (1006, "Insert"),
+    Delete   = (1007, "Delete"),
+    End      = (1008, "End"),
+    PageUp   = (1009, "PageUp"),
+    PageDown = (1010, "PageDown"),
+
+    F1  = (1011, "F1"),
+    F2  = (1012, "F2"),
+    F3  = (1013, "F3"),
+    F4  = (1014, "F4"),
+    F5  = (1015, "F5"),
+    F6  = (1016, "F6"),
+    F7  = (1017, "F7"),
+    F8  = (1018, "F8"),
+    F9  = (1019, "F9"),
+    F10 = (1020, "F10"),
+    F11 = (1021, "F11"),
+    F12 = (1022, "F12"),
+
+    Mouse = (5000, "Mouse")
+
+  IllwillError* = object of Exception
+
+type
+  MouseButtonAction* {.pure.} = enum
+    mbaNone, mbaPressed, mbaReleased
+  MouseInfo* = object
+    x*: int ## x mouse position
+    y*: int ## y mouse position
+    button*: MouseButton ## which button was pressed
+    action*: MouseButtonAction ## if button was released or pressed
+    ctrl*: bool ## was ctrl was down on event
+    shift*: bool ## was shift was down on event
+    scroll*: bool ## if this is a mouse scroll
+    scrollDir*: ScrollDirection
+    move*: bool ## if this a mouse move
+  MouseButton* {.pure.} = enum
+    mbNone, mbLeft, mbMiddle, mbRight
+  ScrollDirection* {.pure.} = enum
+    sdNone, sdUp, sdDown

--- a/definitions.nim
+++ b/definitions.nim
@@ -1,3 +1,20 @@
+import unicode
+
+when defined(js):
+  type
+    Style* = enum
+      styleBright = 1,              ## bright text
+      styleDim,                   ## dim text
+      styleItalic,                ## italic (or reverse on terminals not supporting)
+      styleUnderscore,            ## underscored text
+      styleBlink,                 ## blinking/bold text
+      styleBlinkRapid,            ## rapid blinking/bold text (not widely supported)
+      styleReverse,               ## reverse
+      styleHidden,                ## hidden text
+      styleStrikethrough          ## strikethrough
+else:
+  import terminal
+
 type
   ForegroundColor* = enum   ## Foreground colors
     fgNone = 0,             ## default
@@ -206,3 +223,16 @@ type
     mbNone, mbLeft, mbMiddle, mbRight
   ScrollDirection* {.pure.} = enum
     sdNone, sdUp, sdDown
+  TerminalChar* = object
+    ## Represents a character in the terminal buffer, including color and
+    ## style information.
+    ##
+    ## If `forceWrite` is set to `true`, the character is always output even
+    ## when double buffering is enabled (this is a hack to achieve better
+    ## continuity of horizontal lines when using UTF-8 box drawing symbols in
+    ## the Windows Console).
+    ch*: Rune
+    fg*: ForegroundColor
+    bg*: BackgroundColor
+    style*: set[Style]
+    forceWrite*: bool

--- a/examples/boxdrawing.nim
+++ b/examples/boxdrawing.nim
@@ -14,7 +14,7 @@ proc main() =
   setControlCHook(exitProc)
   hideCursor()
 
-  while true:
+  timerLoop(20):
     var tb = newTerminalBuffer(terminalWidth(), terminalHeight())
 
     var key = getKey()
@@ -102,8 +102,6 @@ proc main() =
              "Check the source code for the description of the test cases ")
 
     tb.display()
-
-    sleep(20)
 
 main()
 

--- a/examples/drawtest.nim
+++ b/examples/drawtest.nim
@@ -70,7 +70,7 @@ proc main() =
   setControlCHook(exitProc)
   hideCursor()
 
-  while true:
+  timerLoop(20):
     var tb = newTerminalBuffer(terminalWidth(), terminalHeight())
 
     if tb.width > gBoxBuffer.width or tb.height > gBoxBuffer.height:
@@ -107,8 +107,6 @@ proc main() =
 
     tb.updateScreen()
     tb.display()
-
-    sleep(20)
 
 main()
 

--- a/examples/fullscreen.nim
+++ b/examples/fullscreen.nim
@@ -1,5 +1,8 @@
 # Simple example that prints out the size of the terminal window and
 # demonstrates the basic structure of a full-screen app.
+#
+# This example specifically does not work with Javascript since
+# the windows size is determined by the calling parameter in the HTML.
 
 import os, strformat
 import illwill

--- a/examples/keycodes.nim
+++ b/examples/keycodes.nim
@@ -54,7 +54,7 @@ proc main() =
   setControlCHook(exitProc)
   hideCursor()
 
-  while true:
+  timerLoop(50):
     var tb = newTerminalBuffer(terminalWidth(), terminalHeight())
 
     var key = getKey()
@@ -65,8 +65,6 @@ proc main() =
 
     tb.updateScreen()
     tb.display()
-
-    sleep(50)
 
 main()
 

--- a/examples/readmeexample.nim
+++ b/examples/readmeexample.nim
@@ -21,7 +21,7 @@ hideCursor()
 var tb = newTerminalBuffer(terminalWidth(), terminalHeight())
 
 # 3. Display some simple static UI that doesn't change from frame to frame.
-tb.setForegroundColor(fgBlack, true)
+tb.setForegroundColor(fgBlue, true)
 tb.drawRect(0, 0, 40, 5)
 tb.drawHorizLine(2, 38, 3, doubleStyle=true)
 

--- a/examples/readmeexample.nim
+++ b/examples/readmeexample.nim
@@ -33,7 +33,7 @@ tb.write(2, 2, "Press ", fgYellow, "ESC", fgWhite,
 # user input (keypress events), do something based on the input, modify the
 # contents of the terminal buffer (if necessary), and then display the new
 # frame.
-while true:
+timerLoop(20):
   var key = getKey()
   case key
   of Key.None: discard
@@ -41,6 +41,4 @@ while true:
   else:
     tb.write(8, 4, ' '.repeat(31))
     tb.write(2, 4, resetStyle, "Key pressed: ", fgGreen, $key)
-
   tb.display()
-  sleep(20)

--- a/examples/simplekeycodes.nim
+++ b/examples/simplekeycodes.nim
@@ -7,9 +7,12 @@
 # input only, so it's best to import only the functions needed for that, as
 # shown below. This way there will be no symbol name clashes when importing
 # the terminal module (e.g. the foreground and background color enums).
+#
+# This example will not work in javascript as it is dependent on the 'terminal'
+# library.
 
 import os, terminal
-from illwill import illwillInit, illwillDeinit, getKey, Key
+from illwill import illwillInit, illwillDeinit, getKey, Key, timerLoop
 
 proc exitProc() {.noconv.} =
   illwillDeinit()
@@ -39,11 +42,9 @@ proc main() =
 
   resetAttributes()
 
-  while true:
+  timerLoop(20):
     var key = getKey()
     if key != Key.None:
       echo key
-    else:
-      sleep(20)
 
 main()

--- a/examples/untitled.html
+++ b/examples/untitled.html
@@ -2,32 +2,19 @@
 <html>
   <head>
     <title>example</title>
-    <script src="drawtest.js"></script>
+    <script src="readmeexample.js"></script>
     <style>
       pre {
-        width: 90%;
         overflow: auto;
         padding: 1em;
-        margin-left: 2em;
         font-size: 1.5em;   
-      }
-      pre span.in {
-        color: green;
-      }
-      pre span.out {
-        color: black;
-      }
-      .center {
-        margin: auto;
-        width: 80%;
-        border: 1px solid brown;
-        padding: 10px;
       }
     </style>
   </head>
   <body onload="illwillOnLoad('terminal', 80, 24);">
+    <h2>readmeexample terminal screen</h2>
     <p>
-      <pre id="terminal" width="80" style="border: 1px solid black">
+      <pre id="terminal">
         initializing...
       </pre>
     </p>

--- a/examples/untitled.html
+++ b/examples/untitled.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+  <head>
+    <title>example</title>
+    <script src="drawtest.js"></script>
+    <style>
+      pre {
+        width: 90%;
+        overflow: auto;
+        padding: 1em;
+        margin-left: 2em;
+        font-size: 1.5em;   
+      }
+      pre span.in {
+        color: green;
+      }
+      pre span.out {
+        color: black;
+      }
+      .center {
+        margin: auto;
+        width: 80%;
+        border: 1px solid brown;
+        padding: 10px;
+      }
+    </style>
+  </head>
+  <body onload="illwillOnLoad('terminal', 80, 24);">
+    <p>
+      <pre id="terminal" width="80" style="border: 1px solid black">
+        initializing...
+      </pre>
+    </p>
+  </body>
+</html>

--- a/illwill.nim
+++ b/illwill.nim
@@ -68,12 +68,12 @@ elif defined(posix):
 elif defined(js):
   import js_support
   import system
+  export definitions.Style
   export js_support.terminalWidth
   export js_support.terminalHeight
   export js_support.terminalSize
   export js_support.hideCursor
   export js_support.showCursor
-  export js_support.Style
   export js_support.eraseScreen
   export js_support.setControlCHook
   export js_support.unsetControlCHook
@@ -728,20 +728,6 @@ proc getKey*(): Key =
         return Key.Mouse
 
 type
-  TerminalChar* = object
-    ## Represents a character in the terminal buffer, including color and
-    ## style information.
-    ##
-    ## If `forceWrite` is set to `true`, the character is always output even
-    ## when double buffering is enabled (this is a hack to achieve better
-    ## continuity of horizontal lines when using UTF-8 box drawing symbols in
-    ## the Windows Console).
-    ch*: Rune
-    fg*: ForegroundColor
-    bg*: BackgroundColor
-    style*: set[Style]
-    forceWrite*: bool
-
   TerminalBuffer* = ref object
     ## A virtual terminal buffer of a fixed width and height. It remembers the
     ## current color and style settings and the current cursor position.
@@ -978,10 +964,7 @@ var
   gCurrFg: ForegroundColor
   gCurrStyle: set[Style]
 
-when defined(js):
-  proc setAttribs(c: TerminalChar) =
-    discard
-else:
+when not defined(js):
   proc setAttribs(c: TerminalChar) =
     if c.bg == bgNone or c.fg == fgNone or c.style == {}:
       resetAttributes()
@@ -1005,6 +988,7 @@ else:
         gCurrStyle = c.style
         setStyle(gCurrStyle)
 
+when not defined(js):
   proc setPos(x, y: Natural) =
     terminal.setCursorPos(x, y)
 

--- a/illwill.nim
+++ b/illwill.nim
@@ -32,223 +32,55 @@
 ## * `Style <https://nim-lang.org/docs/terminal.html#Style>`_
 ##
 
-import macros, os, terminal, unicode, bitops
+import macros, os, unicode, bitops, tables
 
-export terminal.terminalWidth
-export terminal.terminalHeight
-export terminal.terminalSize
-export terminal.hideCursor
-export terminal.showCursor
-export terminal.Style
+import definitions
+export definitions
 
-type
-  ForegroundColor* = enum   ## Foreground colors
-    fgNone = 0,             ## default
-    fgBlack = 30,           ## black
-    fgRed,                  ## red
-    fgGreen,                ## green
-    fgYellow,               ## yellow
-    fgBlue,                 ## blue
-    fgMagenta,              ## magenta
-    fgCyan,                 ## cyan
-    fgWhite                 ## white
-
-  BackgroundColor* = enum   ## Background colors
-    bgNone = 0,             ## default (transparent)
-    bgBlack = 40,           ## black
-    bgRed,                  ## red
-    bgGreen,                ## green
-    bgYellow,               ## yellow
-    bgBlue,                 ## blue
-    bgMagenta,              ## magenta
-    bgCyan,                 ## cyan
-    bgWhite                 ## white
-
-  Key* {.pure.} = enum      ## Supported single key presses and key combinations
-    None = (-1, "None"),
-
-    # Special ASCII characters
-    CtrlA  = (1, "CtrlA"),
-    CtrlB  = (2, "CtrlB"),
-    CtrlC  = (3, "CtrlC"),
-    CtrlD  = (4, "CtrlD"),
-    CtrlE  = (5, "CtrlE"),
-    CtrlF  = (6, "CtrlF"),
-    CtrlG  = (7, "CtrlG"),
-    CtrlH  = (8, "CtrlH"),
-    Tab    = (9, "Tab"),     # Ctrl-I
-    CtrlJ  = (10, "CtrlJ"),
-    CtrlK  = (11, "CtrlK"),
-    CtrlL  = (12, "CtrlL"),
-    Enter  = (13, "Enter"),  # Ctrl-M
-    CtrlN  = (14, "CtrlN"),
-    CtrlO  = (15, "CtrlO"),
-    CtrlP  = (16, "CtrlP"),
-    CtrlQ  = (17, "CtrlQ"),
-    CtrlR  = (18, "CtrlR"),
-    CtrlS  = (19, "CtrlS"),
-    CtrlT  = (20, "CtrlT"),
-    CtrlU  = (21, "CtrlU"),
-    CtrlV  = (22, "CtrlV"),
-    CtrlW  = (23, "CtrlW"),
-    CtrlX  = (24, "CtrlX"),
-    CtrlY  = (25, "CtrlY"),
-    CtrlZ  = (26, "CtrlZ"),
-    Escape = (27, "Escape"),
-
-    CtrlBackslash    = (28, "CtrlBackslash"),
-    CtrlRightBracket = (29, "CtrlRightBracket"),
-
-    # Printable ASCII characters
-    Space           = (32, "Space"),
-    ExclamationMark = (33, "ExclamationMark"),
-    DoubleQuote     = (34, "DoubleQuote"),
-    Hash            = (35, "Hash"),
-    Dollar          = (36, "Dollar"),
-    Percent         = (37, "Percent"),
-    Ampersand       = (38, "Ampersand"),
-    SingleQuote     = (39, "SingleQuote"),
-    LeftParen       = (40, "LeftParen"),
-    RightParen      = (41, "RightParen"),
-    Asterisk        = (42, "Asterisk"),
-    Plus            = (43, "Plus"),
-    Comma           = (44, "Comma"),
-    Minus           = (45, "Minus"),
-    Dot             = (46, "Dot"),
-    Slash           = (47, "Slash"),
-
-    Zero  = (48, "Zero"),
-    One   = (49, "One"),
-    Two   = (50, "Two"),
-    Three = (51, "Three"),
-    Four  = (52, "Four"),
-    Five  = (53, "Five"),
-    Six   = (54, "Six"),
-    Seven = (55, "Seven"),
-    Eight = (56, "Eight"),
-    Nine  = (57, "Nine"),
-
-    Colon        = (58, "Colon"),
-    Semicolon    = (59, "Semicolon"),
-    LessThan     = (60, "LessThan"),
-    Equals       = (61, "Equals"),
-    GreaterThan  = (62, "GreaterThan"),
-    QuestionMark = (63, "QuestionMark"),
-    At           = (64, "At"),
-
-    ShiftA  = (65, "ShiftA"),
-    ShiftB  = (66, "ShiftB"),
-    ShiftC  = (67, "ShiftC"),
-    ShiftD  = (68, "ShiftD"),
-    ShiftE  = (69, "ShiftE"),
-    ShiftF  = (70, "ShiftF"),
-    ShiftG  = (71, "ShiftG"),
-    ShiftH  = (72, "ShiftH"),
-    ShiftI  = (73, "ShiftI"),
-    ShiftJ  = (74, "ShiftJ"),
-    ShiftK  = (75, "ShiftK"),
-    ShiftL  = (76, "ShiftL"),
-    ShiftM  = (77, "ShiftM"),
-    ShiftN  = (78, "ShiftN"),
-    ShiftO  = (79, "ShiftO"),
-    ShiftP  = (80, "ShiftP"),
-    ShiftQ  = (81, "ShiftQ"),
-    ShiftR  = (82, "ShiftR"),
-    ShiftS  = (83, "ShiftS"),
-    ShiftT  = (84, "ShiftT"),
-    ShiftU  = (85, "ShiftU"),
-    ShiftV  = (86, "ShiftV"),
-    ShiftW  = (87, "ShiftW"),
-    ShiftX  = (88, "ShiftX"),
-    ShiftY  = (89, "ShiftY"),
-    ShiftZ  = (90, "ShiftZ"),
-
-    LeftBracket  = (91, "LeftBracket"),
-    Backslash    = (92, "Backslash"),
-    RightBracket = (93, "RightBracket"),
-    Caret        = (94, "Caret"),
-    Underscore   = (95, "Underscore"),
-    GraveAccent  = (96, "GraveAccent"),
-
-    A = (97, "A"),
-    B = (98, "B"),
-    C = (99, "C"),
-    D = (100, "D"),
-    E = (101, "E"),
-    F = (102, "F"),
-    G = (103, "G"),
-    H = (104, "H"),
-    I = (105, "I"),
-    J = (106, "J"),
-    K = (107, "K"),
-    L = (108, "L"),
-    M = (109, "M"),
-    N = (110, "N"),
-    O = (111, "O"),
-    P = (112, "P"),
-    Q = (113, "Q"),
-    R = (114, "R"),
-    S = (115, "S"),
-    T = (116, "T"),
-    U = (117, "U"),
-    V = (118, "V"),
-    W = (119, "W"),
-    X = (120, "X"),
-    Y = (121, "Y"),
-    Z = (122, "Z"),
-
-    LeftBrace  = (123, "LeftBrace"),
-    Pipe       = (124, "Pipe"),
-    RightBrace = (125, "RightBrace"),
-    Tilde      = (126, "Tilde"),
-    Backspace  = (127, "Backspace"),
-
-    # Special characters with virtual keycodes
-    Up       = (1001, "Up"),
-    Down     = (1002, "Down"),
-    Right    = (1003, "Right"),
-    Left     = (1004, "Left"),
-    Home     = (1005, "Home"),
-    Insert   = (1006, "Insert"),
-    Delete   = (1007, "Delete"),
-    End      = (1008, "End"),
-    PageUp   = (1009, "PageUp"),
-    PageDown = (1010, "PageDown"),
-
-    F1  = (1011, "F1"),
-    F2  = (1012, "F2"),
-    F3  = (1013, "F3"),
-    F4  = (1014, "F4"),
-    F5  = (1015, "F5"),
-    F6  = (1016, "F6"),
-    F7  = (1017, "F7"),
-    F8  = (1018, "F8"),
-    F9  = (1019, "F9"),
-    F10 = (1020, "F10"),
-    F11 = (1021, "F11"),
-    F12 = (1022, "F12"),
-
-    Mouse = (5000, "Mouse")
-
-  IllwillError* = object of Exception
-
-type
-  MouseButtonAction* {.pure.} = enum
-    mbaNone, mbaPressed, mbaReleased
-  MouseInfo* = object
-    x*: int ## x mouse position
-    y*: int ## y mouse position
-    button*: MouseButton ## which button was pressed
-    action*: MouseButtonAction ## if button was released or pressed
-    ctrl*: bool ## was ctrl was down on event
-    shift*: bool ## was shift was down on event
-    scroll*: bool ## if this is a mouse scroll
-    scrollDir*: ScrollDirection
-    move*: bool ## if this a mouse move
-  MouseButton* {.pure.} = enum
-    mbNone, mbLeft, mbMiddle, mbRight
-  ScrollDirection* {.pure.} = enum
-    sdNone, sdUp, sdDown
+when defined(windows):
+  import terminal
+  export terminal.terminalWidth
+  export terminal.terminalHeight
+  export terminal.terminalSize
+  export terminal.hideCursor
+  export terminal.showCursor
+  export terminal.Style
+  export terminal.eraseScreen
+elif defined(posix):
+  import posix except Key
+  import
+    tables, 
+    termios,
+    strutils,
+    strformat
+  import terminal except
+    ForegroundColor,
+    BackgroundColor
+  export terminal.terminalWidth
+  export terminal.terminalHeight
+  export terminal.terminalSize
+  export terminal.hideCursor
+  export terminal.showCursor
+  export terminal.Style
+  export terminal.eraseScreen
+  import posix_support
+  export posix_support.timerLoop
+elif defined(js):
+  import js_support
+  import system
+  export js_support.terminalWidth
+  export js_support.terminalHeight
+  export js_support.terminalSize
+  export js_support.hideCursor
+  export js_support.showCursor
+  export js_support.Style
+  export js_support.eraseScreen
+  export js_support.setControlCHook
+  export js_support.unsetControlCHook
+  export js_support.stdout
+  export js_support.stderr
+  export js_support.illwillOnLoad
+  export js_support.timerLoop
 
 var gMouseInfo = MouseInfo()
 var gMouse: bool = false
@@ -468,9 +300,36 @@ when defined(windows):
     discard writeConsole(hStdout, pointer(us[0].addr), DWORD(s.runeLen),
                          numWritten.addr, nil)
 
+elif defined(js):
+
+  let jsKeyMap = {
+    "ArrowUp": Key.Up,
+    "ArrowDown": Key.Down,
+    "ArrowLeft": Key.Left,
+    "ArrowRight": Key.Right
+  }.toTable
+
+  proc getKeyAsync(): Key =
+    result = Key.None
+
+    let rawKey = $js_support.lastKey
+    js_support.lastKey = "".cstring
+    case len(rawKey):
+    of 0:
+      discard
+    of 1:
+      var asciiInt = rawKey[0].ord
+      result = asciiInt.toKey()
+    else:
+      for keyItem in Key:
+        if $keyItem == rawKey:
+          result = keyItem
+          break
+      if result == Key.None:
+        if jsKeyMap.hasKey(rawKey):
+          result = jsKeyMap[rawKey]
+
 else:  # OS X & Linux
-  import posix, tables, termios
-  import strutils, strformat
 
   proc consoleInit()
   proc consoleDeinit()
@@ -722,6 +581,12 @@ when defined(posix):
   proc disableMouse() =
     stdout.write(DisableMouseTrackAny)
     stdout.flushFile()
+elif defined(js):
+  proc enableMouse() =
+    discard
+
+  proc disableMouse() =
+    discard
 else:
   proc enableMouse(hConsoleInput: Handle) =
     var currentMode: DWORD
@@ -752,14 +617,17 @@ proc illwillInit*(fullScreen: bool = true, mouse: bool = false) =
   if gMouse:
     when defined(posix):
       enableMouse()
+    elif defined(js):
+      discard
     else:
       enableMouse(getStdHandle(STD_INPUT_HANDLE))
   gIllwillInitialised = true
   resetAttributes()
 
 proc checkInit() =
-  if not gIllwillInitialised:
-    raise newException(IllwillError, "Illwill not initialised")
+  if not defined(JS):
+    if not gIllwillInitialised:
+      raise newException(IllwillError, "Illwill not initialised")
 
 proc illwillDeinit*() =
   ## Resets the terminal to its previous state. Needs to be called before
@@ -771,6 +639,8 @@ proc illwillDeinit*() =
   if gMouse:
     when defined(posix):
       disableMouse()
+    elif defined(js):
+      discard
     else:
       disableMouse(getStdHandle(STD_INPUT_HANDLE), gOldConsoleModeInput)
   consoleDeinit()
@@ -1108,34 +978,38 @@ var
   gCurrFg: ForegroundColor
   gCurrStyle: set[Style]
 
-proc setAttribs(c: TerminalChar) =
-  if c.bg == bgNone or c.fg == fgNone or c.style == {}:
-    resetAttributes()
-    gCurrBg = c.bg
-    gCurrFg = c.fg
-    gCurrStyle = c.style
-    if gCurrBg != bgNone:
-      setBackgroundColor(cast[terminal.BackgroundColor](gCurrBg))
-    if gCurrFg != fgNone:
-      setForegroundColor(cast[terminal.ForegroundColor](gCurrFg))
-    if gCurrStyle != {}:
-      setStyle(gCurrStyle)
-  else:
-    if c.bg != gCurrBg:
+when defined(js):
+  proc setAttribs(c: TerminalChar) =
+    discard
+else:
+  proc setAttribs(c: TerminalChar) =
+    if c.bg == bgNone or c.fg == fgNone or c.style == {}:
+      resetAttributes()
       gCurrBg = c.bg
-      setBackgroundColor(cast[terminal.BackgroundColor](gCurrBg))
-    if c.fg != gCurrFg:
       gCurrFg = c.fg
-      setForegroundColor(cast[terminal.ForegroundColor](gCurrFg))
-    if c.style != gCurrStyle:
       gCurrStyle = c.style
-      setStyle(gCurrStyle)
+      if gCurrBg != bgNone:
+        setBackgroundColor(cast[terminal.BackgroundColor](gCurrBg))
+      if gCurrFg != fgNone:
+        setForegroundColor(cast[terminal.ForegroundColor](gCurrFg))
+      if gCurrStyle != {}:
+        setStyle(gCurrStyle)
+    else:
+      if c.bg != gCurrBg:
+        gCurrBg = c.bg
+        setBackgroundColor(cast[terminal.BackgroundColor](gCurrBg))
+      if c.fg != gCurrFg:
+        gCurrFg = c.fg
+        setForegroundColor(cast[terminal.ForegroundColor](gCurrFg))
+      if c.style != gCurrStyle:
+        gCurrStyle = c.style
+        setStyle(gCurrStyle)
 
-proc setPos(x, y: Natural) =
-  terminal.setCursorPos(x, y)
+  proc setPos(x, y: Natural) =
+    terminal.setCursorPos(x, y)
 
-proc setXPos(x: Natural) =
-  terminal.setCursorXPos(x)
+  proc setXPos(x: Natural) =
+    terminal.setCursorXPos(x)
 
 proc displayFull(tb: TerminalBuffer) =
   var buf = ""
@@ -1224,10 +1098,12 @@ proc display*(tb: TerminalBuffer) =
       else:
         displayFull(tb)
         gPrevTerminalBuffer = newTerminalBufferFrom(tb)
-    flushFile(stdout)
+    when not defined(js):
+      flushFile(stdout)
   else:
     displayFull(tb)
-    flushFile(stdout)
+    when not defined(js):
+      flushFile(stdout)
     gFullRedrawNextFrame = false
 
 type BoxChar = int

--- a/js_support.nim
+++ b/js_support.nim
@@ -1,0 +1,212 @@
+import
+  unicode,
+  dom
+export dom except Style
+
+import
+  definitions
+
+type Style* = enum
+  styleBright = 1,            ## bright text
+  styleDim,                   ## dim text
+  styleItalic,                ## italic (or reverse on terminals not supporting)
+  styleUnderscore,            ## underscored text
+  styleBlink,                 ## blinking/bold text
+  styleBlinkRapid,            ## rapid blinking/bold text (not widely supported)
+  styleReverse,               ## reverse
+  styleHidden,                ## hidden text
+  styleStrikethrough          ## strikethrough
+
+var
+  stdout*: dom.File  # this has no real meaning in the JS context, but needed for compatibility
+  stderr*: dom.File  # this has no real meaning in the JS context, but needed for compatibility
+
+var
+  preTag: Element
+  preTagId: cstring
+  preTagRowSize: int = 24
+  preTagColumnSize: int = 80
+  cursorRow: int = 0
+  cursorColumn: int = 0
+  screenRows: array[901, seq[Rune]]
+  previousScreenRows: array[901, seq[Rune]]
+
+var lastKey*: cstring = ""
+var globalTimer*: ref Interval
+
+
+proc setRowSize(newSize: int) =
+  if newSize < 2:
+    preTagRowSize = 2
+  elif newSize > 900:
+    preTagRowSize = 900
+  else:
+    preTagRowSize = newSize
+
+
+proc resetScreenRows() =
+  for row in 0 .. preTagRowSize:  # this includes one row past the end
+    screenRows[row] = @[]
+    for col in 0 ..< preTagColumnSize:
+      screenRows[row].add " ".runeAt(0)
+
+resetScreenRows()  # needed during startup
+
+
+proc detectDiff(): bool =
+  result = false
+  for row in 0 ..< preTagRowSize:
+    if $screenRows[row] != $previousScreenRows[row]:
+      result = true
+      # echo "row:    " & $row
+      # echo "before: " & $previousScreenRows[row]
+      # echo "after:  " & $screenRows[row]
+      previousScreenRows[row] = screenRows[row]
+
+
+proc splashIntoPreTag() =
+  if detectDiff():
+    var newHtml = ""
+    for row in 0 ..< preTagRowSize:
+      newHtml &= $screenRows[row]
+      if row < (preTagRowSize - 1):
+        newHtml &= "\n"
+    if preTag.isNil:
+      echo "not loaded yet"
+      return
+    preTag.innerHtml = newHtml.cstring
+
+
+proc eraseScreen*() =
+  if not preTag.isNil:
+    cursorColumn = 0
+    cursorRow = 0
+    resetScreenRows()
+    splashIntoPreTag()
+
+
+proc onkeydown(ev: Event) =
+  # echo $ev.`type`
+  var temp = cast[KeyboardEvent](ev)
+  lastKey = temp.key
+
+
+proc dummyInterval() = 
+  discard
+
+
+proc consoleInit*() =
+  window.addEventListener(
+    "keydown".cstring,
+    onkeydown,
+    false
+  )
+  globalTimer = window.setInterval(dummyInterval, 6000)
+  if not preTag.isNil:
+    splashIntoPreTag()
+    preTag.disabled = false
+
+
+proc consoleDeInit*() =
+  window.clearInterval(globalTimer)
+  window.removeEventListener(
+    "keydown".cstring, 
+    onkeydown
+  )
+  if preTag.isNil:
+    echo "not loaded yet"
+    return
+  preTag.disabled = true
+
+
+proc setPos*(x, y: Natural) =
+  cursorColumn = x
+  cursorRow = y
+  if cursorColumn > 79:
+    echo "sp col too far " & $cursorColumn 
+  if cursorRow > 23:
+    echo "sp row too far " & $cursorRow
+
+
+proc setXPos*(x: Natural) =
+  cursorColumn = x 
+
+
+proc handleWrap() =
+  if cursorColumn > preTagColumnSize:
+    cursorColumn = 0
+    cursorRow += 1
+    if cursorRow > preTagRowSize:
+      for index in 0 ..< preTagRowSize:
+        screenRows[index] = screenRows[index + 1]
+      screenRows[preTagRowSize - 1] = @[]
+      cursorRow = preTagRowSize - 1
+
+
+proc putChar(ch: Rune) = 
+  screenRows[cursorRow][cursorColumn] = ch
+  cursorColumn += 1
+  handleWrap()
+
+
+proc put*(s: string) = 
+  for ch in s.runes:
+    putChar(ch)
+  splashIntoPreTag()
+
+
+proc resetAttributes*() =
+  discard
+
+
+proc showCursor*() =
+  discard
+
+
+proc hideCursor*() =
+  discard
+
+
+proc setCursorPos*(x, y: int) =
+  discard
+
+
+proc terminalWidth*(): int =
+  result = preTagColumnSize - 1
+
+
+proc terminalHeight*(): int =
+  result = preTagRowSize - 1
+
+
+proc terminalSize*(): tuple[w, h: int] =
+  result.w = terminalWidth()
+  result.h = terminalHeight()
+
+
+proc setControlCHook*(hook: proc () {.noconv.}) =
+  discard
+
+
+proc unsetControlCHook*() =
+  discard
+
+
+template timerLoop*(msDelay: int, content: untyped): untyped =
+  globalTimer = window.setInterval(
+    proc() =
+      content
+    , msDelay)
+
+
+proc illwillOnLoad*(domId: cstring, cols, rows: int) {.exportc.} =
+  preTagId = domId
+  preTag = document.getElementById(domId)
+  if preTag.isNil:
+    echo "ERROR: illwillOnLoad cannot find the id of \"" & $domId & "\""
+    return
+  preTagColumnSize = cols
+  setRowSize(rows)
+  cursorColumn = 0
+  cursorRow = 0
+  consoleInit()

--- a/posix_support.nim
+++ b/posix_support.nim
@@ -1,0 +1,10 @@
+import
+  os
+
+import
+  definitions
+
+template timerLoop*(msDelay: int, content: untyped): untyped =
+  while true:
+    content
+    sleep(msDelay)


### PR DESCRIPTION
This is currently a work-in-progress. Please do not accept the PR yet.

This is an attempt to add javascript support to the `illwill` library.

So, both

```bash
nim c readmeexample.nim
```

and

```bash
nim js readmeexample.nim
```

work. The second version creates a javascript file that can be pulled into a web page and started with something like:

```html
<body onload="illwillOnLoad('terminal', 80, 24);">
    <p>
      <pre id="terminal" width="80" style="border: 1px solid black">
        initializing...
      </pre>
    </p>
  </body>
```

Many basic functions are done. Some notes:

* I've added a `timerLoop(ms)` template. This is needed if an app is going to be useful in on both Windows/Linux and on a web page as JS. Since html is event-driven an infinite loop locks up the web page. The JS version of the `timerLoop` template creates an event handler and the non-JS versions sticks to the `while true: .... sleep(20)` pattern seen on a computer.
* Color is not working yet in JS, but will be easy to add next.
* I've started refactoring the code a bit: `definitions.nim` contains types needed everywhere. `js_support.nim`, `posix_support.nim`, and `win_support.nim` will contain code specific to the target platform.
* I'm developing on a Linux computer; so at the moment only the "posix" and "js" targets are being tested. But I have access to a Windows computer; so I will eventually test against Windows. So don't be surprised if Windows not working yet in this PR.