### PR TITLE
Make illwill threadsafe

### DIFF
--- a/illwill.nim
+++ b/illwill.nim
@@ -1103,10 +1103,10 @@ proc write*(tb: var TerminalBuffer, s: string) =
   write(tb, tb.currX, tb.currY, s)
 
 var
-  gPrevTerminalBuffer: TerminalBuffer
-  gCurrBg: BackgroundColor
-  gCurrFg: ForegroundColor
-  gCurrStyle: set[Style]
+  gPrevTerminalBuffer {.threadvar.}: TerminalBuffer
+  gCurrBg {.threadvar.}: BackgroundColor
+  gCurrFg {.threadvar.}: ForegroundColor
+  gCurrStyle {.threadvar.}: set[Style]
 
 proc setAttribs(c: TerminalChar) =
   if c.bg == bgNone or c.fg == fgNone or c.style == {}:
@@ -1243,7 +1243,7 @@ const
   HORIZ = LEFT or RIGHT
   VERT  = UP or DOWN
 
-var gBoxCharsUnicode: array[64, string]
+var gBoxCharsUnicode {.threadvar.}: array[64, string]
 
 gBoxCharsUnicode[0] = " "
 


### PR DESCRIPTION
illwIll cannot be used in a separate thread since it mutates a lot of global variables.
This fixes some of that.