### PR TITLE
Fix Terminal Restoration on Windows for Non-Fullscreen Applications

### DIFF
--- a/illwill.nim
+++ b/illwill.nim
@@ -400,9 +400,12 @@ when defined(windows):
       if getConsoleMode(getStdHandle(STD_OUTPUT_HANDLE), gOldConsoleMode.addr) != 0:
         var mode = gOldConsoleMode and (not ENABLE_WRAP_AT_EOL_OUTPUT)
         discard setConsoleMode(getStdHandle(STD_OUTPUT_HANDLE), mode)
+    else:
+      discard getConsoleMode(getStdHandle(STD_OUTPUT_HANDLE), gOldConsoleMode.addr)
 
   proc consoleDeinit() =
-    discard setConsoleMode(getStdHandle(STD_OUTPUT_HANDLE), gOldConsoleMode)
+    if gOldConsoleMode != 0:
+      discard setConsoleMode(getStdHandle(STD_OUTPUT_HANDLE), gOldConsoleMode)
 
 
   func getKeyAsync(): Key =


### PR DESCRIPTION
Fixes #20 by ensuring that the stdout state is properly recorded during initialization for non-fullscreen apps.