### PR TITLE
Make `getKey` work from threads

### DIFF
--- a/illwill.nim
+++ b/illwill.nim
@@ -557,9 +557,9 @@ else:  # OS X & Linux
   const KeySequenceMaxLen = 100
 
   # global keycode buffer
-  var keyBuf: array[KeySequenceMaxLen, int]
+  var keyBuf {.threadvar.}: array[KeySequenceMaxLen, int]
 
-  let
+  const
     keySequences = {
       ord(Key.Up):        @["\eOA", "\e[A"],
       ord(Key.Down):      @["\eOB", "\e[B"],


### PR DESCRIPTION
In the spirit of low-effort solutions a-la #19.
Makes one variable thread-local and converts one table to a const, thus allowing using `getKey()` from a thread.

I also ask you kindly to make a tagged release, if it's possible, so the patched version could be denoted in nimble dependency requirements of reliant packages/programs.