### PR TITLE
Add workaround for visible cursor after suspend

### DIFF
--- a/illwill.nim
+++ b/illwill.nim
@@ -499,6 +499,7 @@ else:  # OS X & Linux
     # XXX why don't the below 3 lines seem to have any effect?
     resetAttributes()
     showCursor()
+    stdout.write("\n")
     consoleDeinit()
     discard posix.raise(SIGTSTP)
 


### PR DESCRIPTION
Couldn't figure out why it doesn't work,
but printing a newline to stdout seems to work around the issue.
Not sure if you would want to do this or not.

(aside: should 0.3 be merged back into master?)