### PR TITLE
use cast to disable warnings instead of unsafe Key()[HoleEnumConv]

### DIFF
--- a/illwill.nim
+++ b/illwill.nim
@@ -288,17 +288,7 @@ proc getMouse*(): MouseInfo =
 
   return gMouseInfo
 
-
-{.push warning[HoleEnumConv]:off.}
-
-func toKey(c: int): Key =
-  try:
-    result = Key(c)
-  except RangeDefect:  # ignore unknown keycodes
-    result = Key.None
-
-{.pop}
-
+func toKey(c: cint): Key = cast[Key](c)
 
 var gIllwillInitialised = false
 var gFullScreen = false


### PR DESCRIPTION
the whole point is that Key(c) cast causes Holey Enum compiler warnings, this hopefully removes it by just simply using cast[]()

did you think about this? or did you miss it? Please close it if its bs

Commit: ay, looked at the generated source before commit, its generates the same as above code. we don't get warnings anymore.