### PR TITLE
resetAttributes()

### DIFF
--- a/illwill.nim
+++ b/illwill.nim
@@ -1102,10 +1102,10 @@ func getStyle*(tb: var TerminalBuffer): set[Style] =
   result = tb.currStyle
 
 proc resetAttributes*(tb: var TerminalBuffer) =
-  ## Resets the current text attributes to `bgNone`, `fgWhite` and clears
+  ## Resets the current text attributes to `bgNone`, `fgNone` and clears
   ## all style flags.
   tb.setBackgroundColor(bgNone)
-  tb.setForegroundColor(fgWhite)
+  tb.setForegroundColor(fgNone)
   tb.setStyle({})
 
 proc write*(tb: var TerminalBuffer, x, y: Natural, s: string) =


### PR DESCRIPTION
When applying attributes and then calling resetAttributes(), the terminal was not behaving consistently because the default foreground color is fgNone, but resetAttributes() was setting it to fgWhite.

This change makes resetAttributes() return everything to defaults.